### PR TITLE
Prevent app from crashing

### DIFF
--- a/NearITSDK/NITUtils.m
+++ b/NearITSDK/NITUtils.m
@@ -19,6 +19,10 @@
 + (NSString *)fetchAppIdFromApiKey:(NSString *)apiKey {
     NSArray<NSString*> *components = [apiKey componentsSeparatedByString:@"."];
     
+    if ([components count] < 2) {
+        return @"";
+    }
+    
     NSString *payload = [components objectAtIndex:1];
     
     NSInteger module = [payload length] % 4;


### PR DESCRIPTION
When you specify `@"Your-API-Key"` or a similar string without a `"."` as apiKey parameter the app is crashing.